### PR TITLE
修改paddleocr包名以符合安卓的包名规则

### DIFF
--- a/libs/paddleocr/build.gradle
+++ b/libs/paddleocr/build.gradle
@@ -4,7 +4,7 @@ plugins {
 import java.security.MessageDigest
 
 android {
-    namespace = "paddleocr"
+    namespace = "com.baidu.paddleocr"
     ndkVersion '21.1.6352462'
     compileSdk 33
     defaultConfig {


### PR DESCRIPTION
使用命令打包时会提示包名无效，修改gradle配置中的namespace为com.baidu.paddleocr